### PR TITLE
[feature] Add new disable prop to AppCurrency

### DIFF
--- a/Components/Currency/AppCurrency.vue
+++ b/Components/Currency/AppCurrency.vue
@@ -12,6 +12,7 @@
         @input="updateValue"
         v-bind="moneyFormatForComponent"
         v-show="show"
+        :disabled="disable"
         @keyup.native="handleKeyboard"
       />
     </template>
@@ -61,6 +62,10 @@ export default {
       default: 2
     },
     masked: {
+      type: Boolean,
+      default: false
+    },
+    disable: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
Add new prop to disable _v-money_ input.


- Example:

`<component
:is="'AppCurrency'"
                      label="Change"
                      :value="changeValue"
                      v-bind="attrs"
                      :disable="true"
/>`